### PR TITLE
Replace use of type unsigned long.

### DIFF
--- a/src/Compression.hh
+++ b/src/Compression.hh
@@ -61,7 +61,7 @@ namespace orc {
     const char* const data;
     const size_t length;
     const size_t blockSize;
-    std::streamoff position;
+    size_t position;
 
   public:
     SeekableArrayInputStream(std::initializer_list<unsigned char> list,

--- a/src/Compression.hh
+++ b/src/Compression.hh
@@ -55,55 +55,56 @@ namespace orc {
   /**
    * Create a seekable input stream based on a memory range.
    */
-  class SeekableArrayInputStream: public SeekableInputStream {
+  class SeekableArrayInputStream : public SeekableInputStream {
   private:
     std::vector<char> ownedData;
-    char* data;
-    unsigned long length;
-    unsigned long position;
-    unsigned long blockSize;
+    const char* const data;
+    const size_t length;
+    const size_t blockSize;
+    std::streamoff position;
 
   public:
     SeekableArrayInputStream(std::initializer_list<unsigned char> list,
                              long block_size = -1);
-    SeekableArrayInputStream(char* list,
-                             unsigned long length,
+    SeekableArrayInputStream(const char* list,
+                             size_t length,
                              long block_size = -1);
     virtual ~SeekableArrayInputStream();
-    virtual bool Next(const void** data, int*size) override;
-    virtual void BackUp(int count) override;
-    virtual bool Skip(int count) override;
-    virtual google::protobuf::int64 ByteCount() const override;
-    virtual void seek(PositionProvider& position) override;
-    virtual std::string getName() const override;
+
+    bool Next(const void** data, int* size) override;
+    void BackUp(int count) override;
+    bool Skip(int count) override;
+    google::protobuf::int64 ByteCount() const override;
+    void seek(PositionProvider& position) override;
+    std::string getName() const override;
   };
 
   /**
    * Create a seekable input stream based on an input stream.
    */
-  class SeekableFileInputStream: public SeekableInputStream {
+  class SeekableFileInputStream : public SeekableInputStream {
   private:
-    InputStream* input;
-    std::unique_ptr<char[]> buffer;
-    unsigned long offset;
-    unsigned long length;
-    unsigned long position;
-    unsigned long blockSize;
-    unsigned long remainder;
+    InputStream* const input;
+    const std::streamsize length;
+    const size_t blockSize;
+    const std::unique_ptr<char[]> buffer;
+    const std::streamoff offset;
+    std::streamoff position;
+    size_t remainder;
 
   public:
     SeekableFileInputStream(InputStream* input,
-                            unsigned long offset,
-                            unsigned long length,
-                            long blockSize = -1);
+                            std::streamoff offset,
+                            std::streamsize length,
+                            std::streamsize blockSize = -1);
     virtual ~SeekableFileInputStream();
 
-    virtual bool Next(const void** data, int*size) override;
-    virtual void BackUp(int count) override;
-    virtual bool Skip(int count) override;
-    virtual google::protobuf::int64 ByteCount() const override;
-    virtual void seek(PositionProvider& position) override;
-    virtual std::string getName() const override;
+    bool Next(const void** data, int* size) override;
+    void BackUp(int count) override;
+    bool Skip(int count) override;
+    google::protobuf::int64 ByteCount() const override;
+    void seek(PositionProvider& position) override;
+    std::string getName() const override;
   };
 
   /**
@@ -116,6 +117,7 @@ namespace orc {
      createCodec(CompressionKind kind,
                  std::unique_ptr<SeekableInputStream> input,
                  unsigned long bufferSize);
-}
+
+}  // namespace orc
 
 #endif

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -129,7 +129,7 @@ namespace orc {
     // PASS
   }
 
-  static const unsigned long DIRECTORY_SIZE_GUESS = 16 * 1024;
+  static const std::streamsize DIRECTORY_SIZE_GUESS = 16 * 1024;
 
   class ReaderImpl : public Reader {
   private:
@@ -235,15 +235,17 @@ namespace orc {
                          ): stream(std::move(input)), options(opts) {
     isMetadataLoaded = false;
     // figure out the size of the file using the option or filesystem
-    unsigned long size = std::min(options.getTailLocation(), 
-                                  static_cast<unsigned long>
-                                     (stream->getLength()));
+    const std::streamsize size =
+        std::min(options.getTailLocation(),
+                 static_cast<unsigned long>(stream->getLength()));
 
-    //read last bytes into buffer to get PostScript
+    // read last bytes into buffer to get PostScript
     {
-      const size_t readSize = std::min(size, DIRECTORY_SIZE_GUESS);
+      const std::streamsize readSize = std::min(size, DIRECTORY_SIZE_GUESS);
       std::unique_ptr<char[]> buffer(new char[readSize]);
-      stream->read(buffer.get(), size - readSize, readSize);
+      stream->read(buffer.get(),
+                   size - readSize,
+                   readSize);
       readPostscript(buffer.get(), readSize);
       readFooter(buffer.get(), readSize, size);
     }

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -240,12 +240,13 @@ namespace orc {
                                      (stream->getLength()));
 
     //read last bytes into buffer to get PostScript
-    unsigned long readSize = std::min(size, DIRECTORY_SIZE_GUESS);
-    std::unique_ptr<char[]> buffer = 
-      std::unique_ptr<char[]>(new char[readSize]);
-    stream->read(buffer.get(), size - readSize, readSize);
-    readPostscript(buffer.get(), readSize);
-    readFooter(buffer.get(), readSize, size);
+    {
+      const size_t readSize = std::min(size, DIRECTORY_SIZE_GUESS);
+      std::unique_ptr<char[]> buffer(new char[readSize]);
+      stream->read(buffer.get(), size - readSize, readSize);
+      readPostscript(buffer.get(), readSize);
+      readFooter(buffer.get(), readSize, size);
+    }
 
     currentStripe = 0;
     currentRowInStripe = 0;


### PR DESCRIPTION
Replace use of type `unsigned long` with types `size_t` and `std::streamsize`
in function declarations, definitions, data members, and variables
relating to reading and accessing sizes of and indices into contiguous
storage.

This proposal comes in response to preceding email discussion.

Note that there are more uses of type `unsigned long` in the _orc/Reader.hh_ and _orc/Vector.hh_ files that wind up making their way as arguments to the functions changed here. This proposal is already wide enough in scope that I didn't want to widen it further by addressing those.