### PR TITLE
Changes to make orc lib compile in windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,15 +27,25 @@ include_directories(
   ${CMAKE_SOURCE_DIR}/libs/gmock-${GMOCK_VERSION}/include
   ${CMAKE_SOURCE_DIR}/libs/gmock-${GMOCK_VERSION}/gtest/include
   )
-set (GMOCK_LIB "${CMAKE_BINARY_DIR}/libs/gmock-${GMOCK_VERSION}/libgmock_main.a")
-if(NOT APPLE)
+
+if (MSVC)
+  set (GMOCK_LIB "${CMAKE_BINARY_DIR}/libs/gmock-${GMOCK_VERSION}/gmock_main")
+else(MSVC)
+  set (GMOCK_LIB "${CMAKE_BINARY_DIR}/libs/gmock-${GMOCK_VERSION}/libgmock_main.a")
+endif(MSVC)
+
+if(NOT APPLE AND NOT MSVC)
   list (APPEND GMOCK_LIB pthread)
 endif(NOT APPLE)
 enable_testing()
 
 find_package (Protobuf REQUIRED)
 
-set (CXX11_FLAGS "-std=c++11")
+if(NOT MSVC)
+  # Visual studio enables C++11 support by default.
+  set (CXX11_FLAGS "-std=c++11")
+endif(NOT MSVC)
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   #  -stdlib=libc++
   set (COVERAGE_FLAGS "--coverage -g -O0")
@@ -46,6 +56,11 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set (WARN_FLAGS "-Wall")
 endif ()
+
+if(MSVC)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+endif(MSVC)
+
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_FLAGS}")
 

--- a/src/ByteRLE.cc
+++ b/src/ByteRLE.cc
@@ -126,7 +126,7 @@ namespace orc {
       if (remainingValues == 0) {
         readHeader();
       }
-      size_t count = std::min(numValues, remainingValues);
+      size_t count = std::min(numValues, (unsigned long)remainingValues);
       remainingValues -= count;
       numValues -= count;
       // for literals we need to skip over count bytes, which may involve
@@ -137,7 +137,7 @@ namespace orc {
           if (bufferStart == bufferEnd) {
             nextBuffer();
           }
-          unsigned long skipSize = std::min(consumedBytes,
+          unsigned long skipSize = std::min((unsigned long)consumedBytes,
                           static_cast<unsigned long>(bufferEnd - bufferStart));
           bufferStart += skipSize;
           consumedBytes -= skipSize;
@@ -159,7 +159,8 @@ namespace orc {
         readHeader();
       }
       // how many do we read out of this block?
-      unsigned long count = std::min(numValues - position, remainingValues);
+      unsigned long count = std::min(numValues - position,
+		  (unsigned long) remainingValues);
       unsigned long consumed = 0;
       if (repeating) {
         if (notNull) {

--- a/src/ColumnPrinter.cc
+++ b/src/ColumnPrinter.cc
@@ -25,7 +25,7 @@ namespace orc {
     const long* data;
   public:
     LongColumnPrinter(const ColumnVectorBatch& batch);
-    ~LongColumnPrinter() = default;
+    ~LongColumnPrinter() {}
     void printRow(unsigned long rowId) override;
     void reset(const ColumnVectorBatch& batch) override;
   };
@@ -35,7 +35,7 @@ namespace orc {
     const double* data;
   public:
     DoubleColumnPrinter(const ColumnVectorBatch& batch);
-    virtual ~DoubleColumnPrinter() = default;
+    virtual ~DoubleColumnPrinter() {}
     void printRow(unsigned long rowId) override;
     void reset(const ColumnVectorBatch& batch) override;
   };
@@ -46,7 +46,7 @@ namespace orc {
     const long* length;
   public:
     StringColumnPrinter(const ColumnVectorBatch& batch);
-    virtual ~StringColumnPrinter() = default;
+    virtual ~StringColumnPrinter() {}
     void printRow(unsigned long rowId) override;
     void reset(const ColumnVectorBatch& batch) override;
   };

--- a/src/ColumnPrinter.hh
+++ b/src/ColumnPrinter.hh
@@ -42,7 +42,7 @@ namespace orc {
     std::vector<std::unique_ptr<ColumnPrinter> > fields;
   public:
     StructColumnPrinter(const ColumnVectorBatch& batch);
-    virtual ~StructColumnPrinter() = default;
+    virtual ~StructColumnPrinter() {}
     void printRow(unsigned long rowId) override;
     void reset(const ColumnVectorBatch& batch) override;
   };

--- a/src/ColumnReader.cc
+++ b/src/ColumnReader.cc
@@ -47,7 +47,7 @@ namespace orc {
       // page through the values that we want to skip
       // and count how many are non-null
       const size_t MAX_BUFFER_SIZE = 32768;
-      unsigned long bufferSize = std::min(MAX_BUFFER_SIZE, numValues);
+      unsigned long bufferSize = std::min(MAX_BUFFER_SIZE, (size_t) numValues);
       char buffer[MAX_BUFFER_SIZE];
       unsigned long remaining = numValues;
       while (remaining > 0) {

--- a/src/Compression.cc
+++ b/src/Compression.cc
@@ -67,7 +67,7 @@ namespace orc {
       long blkSize): ownedData(values.size()), data(0) {
     length = values.size();
     char *ptr = ownedData.data();
-    for(unsigned char ch: values) {
+    for each(unsigned char ch in values) {
       *(ptr++) = static_cast<char>(ch);
     }
     position = 0;

--- a/src/Exceptions.hh
+++ b/src/Exceptions.hh
@@ -28,7 +28,8 @@ namespace orc {
   public:
     explicit NotImplementedYet(const std::string& what_arg);
     explicit NotImplementedYet(const char* what_arg);
-    NotImplementedYet(const NotImplementedYet&) = default;
+    NotImplementedYet(const NotImplementedYet&)
+      : std::logic_error("Not Implemented Yet") {}
     virtual ~NotImplementedYet();
   };
 
@@ -36,7 +37,7 @@ namespace orc {
   public:
     explicit ParseError(const std::string& what_arg);
     explicit ParseError(const char* what_arg);
-    ParseError(const ParseError&) = default;
+    ParseError(const ParseError&): std::runtime_error("Parse Error") {}
     virtual ~ParseError();
   };
 }

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -83,7 +83,7 @@ namespace orc {
 
   ReaderOptions& ReaderOptions::include(const std::list<int>& include) {
     privateBits->includedColumns.clear();
-    for(int columnId: include) {
+    for each (int columnId in include) {
       privateBits->includedColumns.push_back(columnId);
     }
     return *this;
@@ -91,7 +91,7 @@ namespace orc {
 
   ReaderOptions& ReaderOptions::include(std::initializer_list<int> include) {
     privateBits->includedColumns.clear();
-    for(int columnId: include) {
+    for each(int columnId in include) {
       privateBits->includedColumns.push_back(columnId);
     }
     return *this;
@@ -258,13 +258,13 @@ namespace orc {
     selectedColumns.reset(new bool[footer.types_size()]);
     memset(selectedColumns.get(), 0, 
            static_cast<std::size_t>(footer.types_size()));
-    for(int columnId: options.getInclude()) {
+    for each (int columnId in options.getInclude()) {
       selectTypeParent(columnId);
       selectTypeChildren(columnId);
     }
     schema = convertType(footer.types(0), footer);
     schema->assignIds(0);
-    previousRow = std::numeric_limits<unsigned long>::max();
+    previousRow = (std::numeric_limits<unsigned long>::max)();
   }
                          
   CompressionKind ReaderImpl::getCompression() const { 
@@ -330,7 +330,7 @@ namespace orc {
   void ReaderImpl::selectTypeParent(int columnId) {
     bool* selectedColumnArray = selectedColumns.get();
     for(int parent=0; parent < columnId; ++parent) {
-      for(unsigned int child: footer.types(parent).subtypes()) {
+      for each (unsigned int child in footer.types(parent).subtypes()) {
         if (static_cast<int>(child) == columnId) {
           if (!selectedColumnArray[parent]) {
             selectedColumnArray[parent] = true;
@@ -346,7 +346,7 @@ namespace orc {
     bool* selectedColumnArray = selectedColumns.get();
     if (!selectedColumnArray[columnId]) {
       selectedColumnArray[columnId] = true;
-      for(unsigned int child: footer.types(columnId).subtypes()) {
+      for each(unsigned int child in footer.types(columnId).subtypes()) {
         selectTypeChildren(static_cast<int>(child));
       }
     }

--- a/src/orc/Vector.hh
+++ b/src/orc/Vector.hh
@@ -84,8 +84,6 @@ namespace orc {
 
   struct ColumnVectorBatch {
     ColumnVectorBatch(unsigned long capacity);
-    ColumnVectorBatch(const ColumnVectorBatch&) = delete;
-    ColumnVectorBatch& operator=(const ColumnVectorBatch&) = delete;
     virtual ~ColumnVectorBatch();
 
     // the number of slots available
@@ -98,6 +96,10 @@ namespace orc {
     bool hasNulls;
 
     virtual std::string toString() const = 0;
+
+  private:
+    ColumnVectorBatch(const ColumnVectorBatch&) {}
+    ColumnVectorBatch& operator=(const ColumnVectorBatch&) {}
   };
 
   struct LongVectorBatch: public ColumnVectorBatch {

--- a/test/TestCompression.cc
+++ b/test/TestCompression.cc
@@ -283,13 +283,13 @@ namespace orc {
     EXPECT_EQ(20, len);
     EXPECT_EQ(20, stream.ByteCount());
     {
-      std::list<unsigned long> offsets({100});
+      std::list<unsigned long> offsets {100};
       PositionProvider posn(offsets);
       stream.seek(posn);
     }
     EXPECT_EQ(100, stream.ByteCount());
     {
-      std::list<unsigned long> offsets({5});
+      std::list<unsigned long> offsets {5};
       PositionProvider posn(offsets);
       stream.seek(posn);
     }
@@ -298,7 +298,7 @@ namespace orc {
     checkBytes(static_cast<const char*>(ptr), len, 5);
     EXPECT_EQ(20, len);
     {
-      std::list<unsigned long> offsets({201});
+      std::list<unsigned long> offsets {201};
       PositionProvider posn(offsets);
       EXPECT_THROW(stream.seek(posn), std::logic_error);
       EXPECT_EQ(200, stream.ByteCount());


### PR DESCRIPTION
Hi Folks. 

This change is to make native orc compile in Windows Visual Studio 2010. It contains:

- changes to CMakeLists file so that cmake now can generate a solution file for visual studio
- revert some C++11 features to make the library compile in VS10
  + e.g., default and delete keywords
  + for each
- add parenthesis around std::min/max to avoid conflict with windows predefined macros.  