### PR TITLE
Detect corrupt column statistics

### DIFF
--- a/src/FileStatistics.cc
+++ b/src/FileStatistics.cc
@@ -56,16 +56,20 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<orc::Statistics> stripeStats;
   std::cout << "File " << argv[1] << " has " << reader->getNumberOfStripes()
             << " stripes"  << std::endl;
-  for (unsigned int j = 0; j < reader->getNumberOfStripes(); j++) {
-    stripeStats = reader->getStripeStatistics(j);
-    std::cout << "*** Stripe " << j << " ***" << std::endl << std::endl ;
+  if(reader->getNumberOfStripeStatistics() == 0){
+    std::cout << "File " << argv[1] << " doesn't have stripe statistics"  << std::endl;
+  }else{
+    for (unsigned int j = 0; j < reader->getNumberOfStripeStatistics(); j++) {
+      stripeStats = reader->getStripeStatistics(j);
+      std::cout << "*** Stripe " << j << " ***" << std::endl << std::endl ;
 
-    for(unsigned int k = 0; k < stripeStats->getNumberOfColumns(); ++k) {
-      std::cout << "--- Column " << k << " ---" << std::endl;
-      std::cout << stripeStats->getColumnStatistics(k)->toString()
-                << std::endl;
-   }
- }
+      for(unsigned int k = 0; k < stripeStats->getNumberOfColumns(); ++k) {
+        std::cout << "--- Column " << k << " ---" << std::endl;
+        std::cout << stripeStats->getColumnStatistics(k)->toString()
+                  << std::endl;
+      }
+    }
+  }
 
   return 0;
 }

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -853,6 +853,7 @@ namespace orc {
     // metadata
     bool isMetadataLoaded;
     proto::Metadata metadata;
+    unsigned long numberOfStripeStatistics;
 
     // reading state
     uint64_t previousRow;
@@ -914,6 +915,8 @@ namespace orc {
 
     std::unique_ptr<StripeInformation> getStripe(unsigned long
                                                  ) const override;
+
+    unsigned long getNumberOfStripeStatistics() const override;
 
     std::unique_ptr<Statistics>
     getStripeStatistics(unsigned long stripeIndex) const override;
@@ -1033,6 +1036,10 @@ namespace orc {
 
   unsigned long ReaderImpl::getNumberOfStripes() const {
     return numberOfStripes;
+  }
+
+  unsigned long ReaderImpl::getNumberOfStripeStatistics() const {
+    return numberOfStripeStatistics;
   }
 
   std::unique_ptr<StripeInformation>
@@ -1169,7 +1176,10 @@ namespace orc {
 
   std::unique_ptr<Statistics>
   ReaderImpl::getStripeStatistics(unsigned long stripeIndex) const {
-    if(stripeIndex >= static_cast<unsigned int>(metadata.stripestats_size())) {
+    if(numberOfStripeStatistics == 0){
+      throw std::logic_error("No stripe statistics in file");
+    }
+    if(stripeIndex >= numberOfStripeStatistics) {
       throw std::logic_error("stripe index out of range");
     }
     return std::unique_ptr<Statistics>
@@ -1285,6 +1295,8 @@ namespace orc {
     if (!metadata.ParseFromZeroCopyStream(pbStream.get())) {
       throw ParseError("bad metadata parse");
     }
+
+    numberOfStripeStatistics = metadata.stripestats_size();
   }
 
 

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -166,7 +166,7 @@ namespace orc {
     uint64_t valueCount;
 
   public:
-    ColumnStatisticsImpl(const proto::ColumnStatistics& stats, bool correctStats);
+    ColumnStatisticsImpl(const proto::ColumnStatistics& stats);
     virtual ~ColumnStatisticsImpl();
 
     uint64_t getNumberOfValues() const override {
@@ -417,7 +417,7 @@ namespace orc {
     double sum;
 
   public:
-    DoubleColumnStatisticsImpl(const proto::ColumnStatistics& stats, bool correctStats);
+    DoubleColumnStatisticsImpl(const proto::ColumnStatistics& stats);
     virtual ~DoubleColumnStatisticsImpl();
 
     bool hasMinimum() const override {
@@ -496,7 +496,7 @@ namespace orc {
     int64_t sum;
 
   public:
-    IntegerColumnStatisticsImpl(const proto::ColumnStatistics& stats, bool correctStats);
+    IntegerColumnStatisticsImpl(const proto::ColumnStatistics& stats);
     virtual ~IntegerColumnStatisticsImpl();
 
     bool hasMinimum() const override {
@@ -751,9 +751,9 @@ namespace orc {
 
   ColumnStatistics* convertColumnStatistics(const proto::ColumnStatistics& s, bool correctStats) {
     if (s.has_intstatistics()) {
-      return new IntegerColumnStatisticsImpl(s, correctStats);
+      return new IntegerColumnStatisticsImpl(s);
     } else if (s.has_doublestatistics()) {
-      return new DoubleColumnStatisticsImpl(s, correctStats);
+      return new DoubleColumnStatisticsImpl(s);
     } else if (s.has_stringstatistics()) {
       return new StringColumnStatisticsImpl(s, correctStats);
     } else if (s.has_bucketstatistics()) {
@@ -767,7 +767,7 @@ namespace orc {
     } else if (s.has_binarystatistics()) {
       return new BinaryColumnStatisticsImpl(s, correctStats);
     } else {
-      return new ColumnStatisticsImpl(s, correctStats);
+      return new ColumnStatisticsImpl(s);
     }
   }
 
@@ -1557,7 +1557,7 @@ namespace orc {
   }
 
   ColumnStatisticsImpl::ColumnStatisticsImpl
-  (const proto::ColumnStatistics& pb, bool correctStats) {
+  (const proto::ColumnStatistics& pb) {
     valueCount = pb.numberofvalues();
   }
 
@@ -1617,7 +1617,7 @@ namespace orc {
   }
 
   DoubleColumnStatisticsImpl::DoubleColumnStatisticsImpl
-  (const proto::ColumnStatistics& pb, bool correctStats){
+  (const proto::ColumnStatistics& pb){
     valueCount = pb.numberofvalues();
     if (!pb.has_doublestatistics()) {
       _hasMinimum = false;
@@ -1636,7 +1636,7 @@ namespace orc {
   }
 
   IntegerColumnStatisticsImpl::IntegerColumnStatisticsImpl
-  (const proto::ColumnStatistics& pb, bool correctStats){
+  (const proto::ColumnStatistics& pb){
     valueCount = pb.numberofvalues();
     if (!pb.has_intstatistics()) {
       _hasMinimum = false;

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -941,7 +941,7 @@ namespace orc {
 
     MemoryPool* getMemoryPool() const ;
     
-    bool hasCorrectStats() const override;
+    bool hasCorrectStatatistics() const override;
   };
 
   InputStream::~InputStream() {
@@ -1154,7 +1154,7 @@ namespace orc {
   }
 
   std::unique_ptr<Statistics> ReaderImpl::getStatistics() const {
-    return std::unique_ptr<Statistics>(new StatisticsImpl(footer, hasCorrectStats()));
+    return std::unique_ptr<Statistics>(new StatisticsImpl(footer, hasCorrectStatistics()));
   }
 
   std::unique_ptr<ColumnStatistics>
@@ -1164,7 +1164,7 @@ namespace orc {
     }
     proto::ColumnStatistics col = footer.statistics(static_cast<int>(index));
     return std::unique_ptr<ColumnStatistics> (convertColumnStatistics
-                                              (col, hasCorrectStats()));
+                                              (col, hasCorrectStatistics()));
   }
 
   std::unique_ptr<Statistics>
@@ -1174,7 +1174,7 @@ namespace orc {
     }
     return std::unique_ptr<Statistics>
       (new StatisticsImpl(metadata.stripestats
-                          (static_cast<int>(stripeIndex)), hasCorrectStats()));
+                          (static_cast<int>(stripeIndex)), hasCorrectStatistics()));
   }
 
 
@@ -1186,7 +1186,7 @@ namespace orc {
     return memoryPool;
   }
 
-  bool ReaderImpl::hasCorrectStats() const {
+  bool ReaderImpl::hasCorrectStatistics() const {
       return postscript.has_writerversion() && postscript.writerversion();
   }
 

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -941,7 +941,7 @@ namespace orc {
 
     MemoryPool* getMemoryPool() const ;
     
-    bool hasCorrectStatatistics() const override;
+    bool hasCorrectStatistics() const override;
   };
 
   InputStream::~InputStream() {
@@ -1187,7 +1187,7 @@ namespace orc {
   }
 
   bool ReaderImpl::hasCorrectStatistics() const {
-      return postscript.has_writerversion() && postscript.writerversion();
+    return postscript.has_writerversion() && postscript.writerversion();
   }
 
   void ReaderImpl::readPostscript(char *buffer, unsigned long readSize) {

--- a/src/Reader.cc
+++ b/src/Reader.cc
@@ -1296,7 +1296,7 @@ namespace orc {
       throw ParseError("bad metadata parse");
     }
 
-    numberOfStripeStatistics = metadata.stripestats_size();
+    numberOfStripeStatistics = static_cast<unsigned long>(metadata.stripestats_size());
   }
 
 

--- a/src/orc/Reader.hh
+++ b/src/orc/Reader.hh
@@ -583,6 +583,12 @@ namespace orc {
     getStripe(unsigned long stripeIndex) const = 0;
 
     /**
+     * Get the number of stripe statistics in the file.
+     * @return the number of stripe statistics
+     */
+    virtual unsigned long getNumberOfStripeStatistics() const = 0;
+
+    /**
      * Get the statistics about a stripe.
      * @param stripeIndex the stripe 0 to N-1 to get statistics about
      * @return the statistics about that stripe

--- a/src/orc/Reader.hh
+++ b/src/orc/Reader.hh
@@ -658,7 +658,7 @@ namespace orc {
     /**
      * check file has correct column statistics
      */
-    virtual bool hasCorrectStatatistics() const = 0;
+    virtual bool hasCorrectStatistics() const = 0;
   };
 }
 

--- a/src/orc/Reader.hh
+++ b/src/orc/Reader.hh
@@ -658,7 +658,7 @@ namespace orc {
     /**
      * check file has correct column statistics
      */
-    virtual bool hasCorrectStats() const = 0;
+    virtual bool hasCorrectStatatistics() const = 0;
   };
 }
 

--- a/src/orc/Reader.hh
+++ b/src/orc/Reader.hh
@@ -654,6 +654,11 @@ namespace orc {
      * Get the name of the input stream.
      */
     virtual const std::string& getStreamName() const = 0;
+
+    /**
+     * check file has correct column statistics
+     */
+    virtual bool hasCorrectStats() const = 0;
   };
 }
 

--- a/test/TestReader.cc
+++ b/test/TestReader.cc
@@ -459,6 +459,8 @@ TEST(Reader, corruptStatistics) {
   std::unique_ptr<orc::Reader> reader =
     orc::createReader(orc::readLocalFile(filename.str()), opts);
 
+  EXPECT_EQ(false, reader->hasCorrectStats());
+
   // 2nd real column, string
   std::unique_ptr<orc::ColumnStatistics> col_2 =
     reader->getColumnStatistics(2);

--- a/test/TestReader.cc
+++ b/test/TestReader.cc
@@ -399,6 +399,9 @@ TEST(Reader, columnStatistics) {
   std::unique_ptr<orc::Reader> reader =
     orc::createReader(orc::readLocalFile(filename.str()), opts);
 
+  // corrupt stats test
+  EXPECT_EQ(true, reader->hasCorrectStatistics());
+
   // test column statistics
   std::unique_ptr<orc::Statistics> stats = reader->getStatistics();
   EXPECT_EQ(10, stats->getNumberOfColumns());
@@ -459,7 +462,7 @@ TEST(Reader, corruptStatistics) {
   std::unique_ptr<orc::Reader> reader =
     orc::createReader(orc::readLocalFile(filename.str()), opts);
 
-  EXPECT_EQ(false, reader->hasCorrectStats());
+  EXPECT_EQ(false, reader->hasCorrectStatistics());
 
   // 2nd real column, string
   std::unique_ptr<orc::ColumnStatistics> col_2 =

--- a/test/TestReader.cc
+++ b/test/TestReader.cc
@@ -432,6 +432,8 @@ TEST(Reader, stripeStatistics) {
     orc::createReader(orc::readLocalFile(filename.str()), opts);
 
   // test stripe statistics
+  EXPECT_EQ(385, reader->getNumberOfStripeStatistics());
+
   // stripe[384]: 385th stripe, last stripe
   unsigned long stripeIdx = 384;
   std::unique_ptr<orc::Statistics> stripeStats =
@@ -477,11 +479,23 @@ TEST(Reader, corruptStatistics) {
   std::unique_ptr<orc::Statistics> stripeStats =
     reader->getStripeStatistics(stripeIdx);
 
-  // 4th real column, Timestamp
+  // 4th real column, Decimal
   const orc::DecimalColumnStatistics* col_4 =
     dynamic_cast<const orc::DecimalColumnStatistics*>
     (stripeStats->getColumnStatistics(4));
   EXPECT_EQ(false, col_4->hasMinimum());
   EXPECT_EQ(false, col_4->hasMaximum());
 }
+
+TEST(Reader, noStripeStatistics) {
+  orc::ReaderOptions opts;
+  std::ostringstream filename;
+  // read the file has no stripe statistics
+  filename << exampleDirectory << "/orc-file-11-format.orc";
+  std::unique_ptr<orc::Reader> reader =
+    orc::createReader(orc::readLocalFile(filename.str()), opts);
+
+  EXPECT_EQ(0, reader->getNumberOfStripeStatistics());  
+}
+
 }  // namespace

--- a/test/TestReader.cc
+++ b/test/TestReader.cc
@@ -403,19 +403,19 @@ TEST(Reader, columnStatistics) {
   std::unique_ptr<orc::Statistics> stats = reader->getStatistics();
   EXPECT_EQ(10, stats->getNumberOfColumns());
 
-  // column[5]
-  std::unique_ptr<orc::ColumnStatistics> col_5 =
+  // 6th real column, start from 1
+  std::unique_ptr<orc::ColumnStatistics> col_6 =
     reader->getColumnStatistics(6);
   const orc::StringColumnStatistics& strStats =
-    dynamic_cast<const orc::StringColumnStatistics&> (*(col_5.get()));
+    dynamic_cast<const orc::StringColumnStatistics&> (*(col_6.get()));
   EXPECT_EQ("Good", strStats.getMinimum());
   EXPECT_EQ("Unknown", strStats.getMaximum());
 
-  // column[6]
-  std::unique_ptr<orc::ColumnStatistics> col_6 =
+  // 7th real column
+  std::unique_ptr<orc::ColumnStatistics> col_7 =
     reader->getColumnStatistics(7);
   const orc::IntegerColumnStatistics& intStats =
-    dynamic_cast<const orc::IntegerColumnStatistics&> (*(col_6.get()));
+    dynamic_cast<const orc::IntegerColumnStatistics&> (*(col_7.get()));
   EXPECT_EQ(0, intStats.getMinimum());
   EXPECT_EQ(6, intStats.getMaximum());
   EXPECT_EQ(5762400, intStats.getSum());
@@ -429,26 +429,54 @@ TEST(Reader, stripeStatistics) {
     orc::createReader(orc::readLocalFile(filename.str()), opts);
 
   // test stripe statistics
-  // stripe[60]
-  unsigned long stripeIdx = 60;
+  // stripe[384]: 385th stripe, last stripe
+  unsigned long stripeIdx = 384;
   std::unique_ptr<orc::Statistics> stripeStats =
     reader->getStripeStatistics(stripeIdx);
   EXPECT_EQ(10, stripeStats->getNumberOfColumns());
 
-  // column[5]
-  const StringColumnStatistics* col_5 =
-    dynamic_cast<const StringColumnStatistics*>
+  // 6th real column
+  const orc::StringColumnStatistics* col_6 =
+    dynamic_cast<const orc::StringColumnStatistics*>
     (stripeStats->getColumnStatistics(6));
-  EXPECT_EQ("Good", col_5->getMinimum());
-  EXPECT_EQ("Unknown", col_5->getMaximum());
+  EXPECT_EQ("Unknown", col_6->getMinimum());
+  EXPECT_EQ("Unknown", col_6->getMaximum());
 
-  // column[6]
-  const IntegerColumnStatistics* col_6 =
-    dynamic_cast<const IntegerColumnStatistics*>
+  // 7th real column
+  const orc::IntegerColumnStatistics* col_7 =
+    dynamic_cast<const orc::IntegerColumnStatistics*>
     (stripeStats->getColumnStatistics(7));
-  EXPECT_EQ(4, col_6->getMinimum());
-  EXPECT_EQ(5, col_6->getMaximum());
-  EXPECT_EQ(22600, col_6->getSum());
+  EXPECT_EQ(6, col_7->getMinimum());
+  EXPECT_EQ(6, col_7->getMaximum());
+  EXPECT_EQ(4800, col_7->getSum());
 }
 
+TEST(Reader, corruptStatistics) {
+  orc::ReaderOptions opts;
+  std::ostringstream filename;
+  // read the file has corrupt statistics
+  filename << exampleDirectory << "/orc_split_elim.orc";
+  std::unique_ptr<orc::Reader> reader =
+    orc::createReader(orc::readLocalFile(filename.str()), opts);
+
+  // 2nd real column, string
+  std::unique_ptr<orc::ColumnStatistics> col_2 =
+    reader->getColumnStatistics(2);
+  const orc::StringColumnStatistics& strStats =
+    dynamic_cast<const orc::StringColumnStatistics&> (*(col_2.get()));
+  EXPECT_EQ(false, strStats.hasMinimum());
+  EXPECT_EQ(false, strStats.hasMaximum());
+  
+  // stripe statistics
+  unsigned long stripeIdx = 1;
+  std::unique_ptr<orc::Statistics> stripeStats =
+    reader->getStripeStatistics(stripeIdx);
+
+  // 4th real column, Timestamp
+  const orc::DecimalColumnStatistics* col_4 =
+    dynamic_cast<const orc::DecimalColumnStatistics*>
+    (stripeStats->getColumnStatistics(4));
+  EXPECT_EQ(false, col_4->hasMinimum());
+  EXPECT_EQ(false, col_4->hasMaximum());
+}
 }  // namespace


### PR DESCRIPTION
1. Detect corrupt column statistics based on writerVersion in postscript. 
2. If col stats corrupt, reader would not give statistics for columns except Integer and Double.
