### PR TITLE
Move towards asio buffers and read API: part 1

### DIFF
--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -31,24 +31,6 @@
 namespace orc {
 
   /**
-   * An abstract interface for a buffer provided by the input stream.
-   */
-  class Buffer {
-  public:
-    virtual ~Buffer();
-
-    /**
-     * Get the start of the buffer.
-     */
-    virtual char *getStart() const = 0;
-
-    /**
-     * Get the length of the buffer in bytes.
-     */
-    virtual uint64_t getLength() const = 0;
-  };
-
-  /**
    * An abstract interface for providing ORC readers a stream of bytes.
    */
   class InputStream {
@@ -62,17 +44,15 @@ namespace orc {
 
     /**
      * Read length bytes from the file starting at offset into
-     * the buffer.
-     * @param offset the position in the file to read from
-     * @param length the number of bytes to read
-     * @param buffer a Buffer to reuse from a previous call to read. Ownership
-     *    of this buffer passes to the InputStream object.
-     * @return the buffer with the requested data. The client owns the Buffer.
+     * the buffer starting at buf.
+     * @param buf the starting position of a buffer.
+     * @param length the number of bytes to read.
+     * @param offset the position in the stream to read from.
+     * @return the number of bytes read.
      */
-    virtual Buffer* read(uint64_t offset,
+    virtual void read(void* buf,
                          uint64_t length,
-                         Buffer* buffer) = 0;
-
+                         uint64_t offset) = 0;
     /**
      * Get the name of the stream for error messages.
      */

--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -48,7 +48,6 @@ namespace orc {
      * @param buf the starting position of a buffer.
      * @param length the number of bytes to read.
      * @param offset the position in the stream to read from.
-     * @return the number of bytes read.
      */
     virtual void read(void* buf,
                          uint64_t length,

--- a/c++/src/orc/Compression.cc
+++ b/c++/src/orc/Compression.cc
@@ -59,10 +59,7 @@ namespace orc {
     return result;
   }
 
-  SeekableInputStream::SeekableInputStream(
-                                        MemoryPool& _pool = *getDefaultPool()):
-                                        pool(_pool) {
-  }
+  SeekableInputStream::SeekableInputStream(MemoryPool& _pool): pool(_pool) {}
 
   SeekableInputStream::~SeekableInputStream() {
     // PASS

--- a/c++/src/orc/Compression.hh
+++ b/c++/src/orc/Compression.hh
@@ -50,7 +50,10 @@ namespace orc {
    * to the protobuf readers.
    */
   class SeekableInputStream: public google::protobuf::io::ZeroCopyInputStream {
+  protected:
+    MemoryPool& pool;
   public:
+    SeekableInputStream(MemoryPool& pool);
     virtual ~SeekableInputStream();
     virtual void seek(PositionProvider& position) = 0;
     virtual std::string getName() const = 0;
@@ -61,19 +64,12 @@ namespace orc {
    */
   class SeekableArrayInputStream: public SeekableInputStream {
   private:
-    std::unique_ptr<DataBuffer<char> > ownedData;
     const char* data;
     uint64_t length;
     uint64_t position;
     uint64_t blockSize;
 
   public:
-
-    #ifdef ORC_CXX_HAS_INITIALIZER_LIST
-      SeekableArrayInputStream(std::initializer_list<unsigned char> list,
-                               int64_t block_size = -1);
-    #endif
-
     SeekableArrayInputStream(const unsigned char* list,
                              uint64_t length,
                              int64_t block_size = -1);
@@ -98,7 +94,7 @@ namespace orc {
     const uint64_t start;
     const uint64_t length;
     const uint64_t blockSize;
-    Buffer* buffer;
+    std::unique_ptr<DataBuffer<char> > buffer;
     uint64_t position;
     uint64_t pushBack;
 
@@ -106,6 +102,7 @@ namespace orc {
     SeekableFileInputStream(InputStream* input,
                             uint64_t offset,
                             uint64_t byteCount,
+                            MemoryPool& pool,
                             int64_t blockSize = -1);
     virtual ~SeekableFileInputStream();
 

--- a/c++/src/orc/Compression.hh
+++ b/c++/src/orc/Compression.hh
@@ -53,7 +53,7 @@ namespace orc {
   protected:
     MemoryPool& pool;
   public:
-    SeekableInputStream(MemoryPool& pool);
+    SeekableInputStream(MemoryPool& pool = *getDefaultPool());
     virtual ~SeekableInputStream();
     virtual void seek(PositionProvider& position) = 0;
     virtual std::string getName() const = 0;

--- a/c++/src/orc/OrcFile.cc
+++ b/c++/src/orc/OrcFile.cc
@@ -30,36 +30,6 @@
 
 namespace orc {
 
-  Buffer::~Buffer() {
-    // PASS
-  }
-
-  class HeapBuffer: public Buffer {
-  private:
-    char* start;
-    uint64_t length;
-
-  public:
-    HeapBuffer(uint64_t size) {
-      start = new char[size];
-      length = size;
-    }
-
-    virtual ~HeapBuffer();
-
-    virtual char *getStart() const override {
-      return start;
-    }
-
-    virtual uint64_t getLength() const override {
-      return length;
-    }
-  };
-
-  HeapBuffer::~HeapBuffer() {
-    delete[] start;
-  }
-
   class FileInputStream : public InputStream {
   private:
     std::string filename ;
@@ -86,24 +56,20 @@ namespace orc {
       return totalLength;
     }
 
-    Buffer* read(uint64_t offset,
-                 uint64_t length,
-                 Buffer* buffer) override {
-      if (buffer == nullptr) {
-        buffer = new HeapBuffer(length);
-      } else if (buffer->getLength() < length) {
-        delete buffer;
-        buffer = new HeapBuffer(length);
+    void read(void* buf,
+              uint64_t length,
+              uint64_t offset) override {
+      if (!buf) {
+        throw ParseError("Buffer is null");
       }
-      ssize_t bytesRead = pread(file, buffer->getStart(), length,
-                                static_cast<off_t>(offset));
+
+      ssize_t bytesRead = pread(file, buf, length, static_cast<off_t>(offset));
       if (bytesRead == -1) {
         throw ParseError("Bad read of " + filename);
       }
       if (static_cast<uint64_t>(bytesRead) != length) {
         throw ParseError("Short read of " + filename);
       }
-      return buffer;
     }
 
     const std::string& getName() const override {
@@ -113,40 +79,6 @@ namespace orc {
 
   FileInputStream::~FileInputStream() {
     close(file);
-  }
-
-  /**
-   * A buffer for use with an memmapped file where the Buffer doesn't own
-   * the memory that it references.
-   */
-  class MmapBuffer: public Buffer {
-  private:
-    char* start;
-    uint64_t length;
-
-  public:
-    MmapBuffer(): start(nullptr), length(0) {
-      // PASS
-    }
-
-    virtual ~MmapBuffer();
-
-    void reset(char *_start, uint64_t _length) {
-      start = _start;
-      length = _length;
-    }
-
-    virtual char *getStart() const override {
-      return start;
-    }
-
-    virtual uint64_t getLength() const override {
-      return length;
-    }
-  };
-
-  MmapBuffer::~MmapBuffer() {
-    // PASS
   }
 
   /**
@@ -171,9 +103,9 @@ namespace orc {
       return filename;
     }
 
-    Buffer* read(uint64_t offset,
-                 uint64_t length,
-                 Buffer* buffer) override;
+    void read(void* buf,
+              uint64_t length,
+              uint64_t offset) override;
   };
 
   MmapInputStream::MmapInputStream(std::string _filename) {
@@ -205,17 +137,13 @@ namespace orc {
     }
   }
 
-  Buffer* MmapInputStream::read(uint64_t offset,
-                                uint64_t length,
-                                Buffer* buffer) {
-    if (buffer == nullptr) {
-      buffer = new MmapBuffer();
-    }
+  void MmapInputStream::read(void* buf,
+                             uint64_t length,
+                             uint64_t offset) {
     if (offset + length > totalLength) {
       throw std::runtime_error("Read past end of file " + filename);
     }
-    dynamic_cast<MmapBuffer*>(buffer)->reset(start + offset, length);
-    return buffer;
+    buf = start + offset;
   }
 
   std::unique_ptr<InputStream> readLocalFile(const std::string& path) {

--- a/c++/test/orc/TestCompression.cc
+++ b/c++/test/orc/TestCompression.cc
@@ -204,7 +204,7 @@ namespace orc {
   TEST_F(TestCompression, testFileBackup) {
     SCOPED_TRACE("testFileBackup");
     std::unique_ptr<InputStream> file = readLocalFile(simpleFile);
-    SeekableFileInputStream stream(file.get(), 0, 200, 20);
+    SeekableFileInputStream stream(file.get(), 0, 200, *getDefaultPool(), 20);
     const void *ptr;
     int len;
     ASSERT_THROW(stream.BackUp(10), std::logic_error);
@@ -235,7 +235,7 @@ namespace orc {
   TEST_F(TestCompression, testFileSkip) {
     SCOPED_TRACE("testFileSkip");
     std::unique_ptr<InputStream> file = readLocalFile(simpleFile);
-    SeekableFileInputStream stream(file.get(), 0, 200, 20);
+    SeekableFileInputStream stream(file.get(), 0, 200, *getDefaultPool(), 20);
     const void *ptr;
     int len;
     ASSERT_EQ(true, stream.Next(&ptr, &len));
@@ -255,7 +255,7 @@ namespace orc {
   TEST_F(TestCompression, testFileCombo) {
     SCOPED_TRACE("testFileCombo");
     std::unique_ptr<InputStream> file = readLocalFile(simpleFile);
-    SeekableFileInputStream stream(file.get(), 0, 200, 20);
+    SeekableFileInputStream stream(file.get(), 0, 200, *getDefaultPool(), 20);
     const void *ptr;
     int len;
     ASSERT_EQ(true, stream.Next(&ptr, &len));
@@ -275,7 +275,7 @@ namespace orc {
   TEST_F(TestCompression, testFileSeek) {
     SCOPED_TRACE("testFileSeek");
     std::unique_ptr<InputStream> file = readLocalFile(simpleFile);
-    SeekableFileInputStream stream(file.get(), 0, 200, 20);
+    SeekableFileInputStream stream(file.get(), 0, 200, *getDefaultPool(), 20);
     const void *ptr;
     int len;
     EXPECT_EQ(0, stream.ByteCount());


### PR DESCRIPTION
To move towards asio buffer API and introduce async_read_at() function, we first need to clean up the existing code. Code changes in this pull request:
a) removed Buffer and its subclasses and replaced them with DataBuffer<char>
b) made InputStream::read() method to be posix-like
